### PR TITLE
Added mlocking for secret types.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,11 @@ categories = ["cryptography"]
 
 [dependencies]
 byteorder = "1.2.3"
+errno = "0.2.4"
 failure = "0.1"
 init_with = "1.1.0"
 log = "0.4.1"
+memsec = "0.5.4"
 pairing = { version = "0.14.2", features = ["u128-support"] }
 rand = "0.4.2"
 rand_derive = "0.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ byteorder = "1.2.3"
 errno = "0.2.4"
 failure = "0.1"
 init_with = "1.1.0"
+lazy_static = "1.1.0"
 log = "0.4.1"
 memsec = "0.5.4"
 pairing = { version = "0.14.2", features = ["u128-support"] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,7 @@
 //! Crypto errors.
 
+use errno::Errno;
+
 /// A crypto error.
 #[derive(Clone, Eq, PartialEq, Debug, Fail)]
 pub enum Error {
@@ -7,6 +9,32 @@ pub enum Error {
     NotEnoughShares,
     #[fail(display = "Signature shares contain a duplicated index")]
     DuplicateEntry,
+    #[fail(
+        display = "Failed to `mlock` {} bytes starting at address: {}",
+        n_bytes,
+        addr
+    )]
+    MlockFailed {
+        // The errno set by the failed `mlock` syscall.
+        errno: Errno,
+        // The address for the first byte in the range of memory that was attempted to be locked.
+        addr: String,
+        // The number of bytes that were attempted to be locked.
+        n_bytes: usize,
+    },
+    #[fail(
+        display = "Failed to `munlock` {} bytes starting at address: {}",
+        n_bytes,
+        addr
+    )]
+    MunlockFailed {
+        // The errno set by the failed `munlock` syscall.
+        errno: Errno,
+        // The address for the first byte in the range of memory that was attempted to be unlocked.
+        addr: String,
+        // The number of bytes that were attempted to be unlocked.
+        n_bytes: usize,
+    },
 }
 
 unsafe impl Send for Error {}

--- a/src/poly.rs
+++ b/src/poly.rs
@@ -28,7 +28,7 @@ use pairing::bls12_381::{Fr, G1, G1Affine};
 use pairing::{CurveAffine, CurveProjective, Field};
 use rand::Rng;
 
-use super::{ContainsSecret, Error, IntoFr, Result};
+use super::{ContainsSecret, Error, IntoFr, Result, SHOULD_MLOCK_SECRETS};
 
 /// A univariate polynomial in the prime field.
 #[derive(Serialize, Deserialize, PartialEq, Eq)]
@@ -288,6 +288,9 @@ impl Drop for Poly {
 
 impl ContainsSecret for Poly {
     fn mlock_secret_memory(&self) -> Result<()> {
+        if !*SHOULD_MLOCK_SECRETS {
+            return Ok(());
+        }
         let ptr = self.coeff.as_ptr() as *mut u8;
         let n_bytes = size_of_val(self.coeff.as_slice());
         if n_bytes == 0 {
@@ -307,6 +310,9 @@ impl ContainsSecret for Poly {
     }
 
     fn munlock_secret_memory(&self) -> Result<()> {
+        if !*SHOULD_MLOCK_SECRETS {
+            return Ok(());
+        }
         let ptr = self.coeff.as_ptr() as *mut u8;
         let n_bytes = size_of_val(self.coeff.as_slice());
         if n_bytes == 0 {
@@ -510,6 +516,9 @@ impl Poly {
 
     // Removes the `mlock` for `len` elements that have been truncated from the `coeff` vector.
     fn truncate_mlock(&self, len: usize) -> Result<()> {
+        if !*SHOULD_MLOCK_SECRETS {
+            return Ok(());
+        }
         let n_bytes_truncated = len * size_of::<Fr>();
         if n_bytes_truncated == 0 {
             return Ok(());
@@ -532,6 +541,9 @@ impl Poly {
 
     // Extends the `mlock` on the `coeff` vector when `len` new elements are added.
     fn extend_mlock(&self, len: usize) -> Result<()> {
+        if !*SHOULD_MLOCK_SECRETS {
+            return Ok(());
+        }
         let n_bytes_extended = len * size_of::<Fr>();
         if n_bytes_extended == 0 {
             return Ok(());
@@ -684,6 +696,9 @@ impl Debug for BivarPoly {
 
 impl ContainsSecret for BivarPoly {
     fn mlock_secret_memory(&self) -> Result<()> {
+        if !*SHOULD_MLOCK_SECRETS {
+            return Ok(());
+        }
         let ptr = self.coeff.as_ptr() as *mut u8;
         let n_bytes = size_of_val(self.coeff.as_slice());
         if n_bytes == 0 {
@@ -703,6 +718,9 @@ impl ContainsSecret for BivarPoly {
     }
 
     fn munlock_secret_memory(&self) -> Result<()> {
+        if !*SHOULD_MLOCK_SECRETS {
+            return Ok(());
+        }
         let ptr = self.coeff.as_ptr() as *mut u8;
         let n_bytes = size_of_val(self.coeff.as_slice());
         if n_bytes == 0 {


### PR DESCRIPTION
- Added trait `ContainsSecret`.
- Added `mlock` and `munlock` for secret types.
- Removed stack copying of secret prime field elements.
- Changed `SecretKey(Fr)` to `SecretKey(Box<Fr>)`.
- Added [`memsec`](https://crates.io/crates/memsec) and [`errno`](https://crates.io/crates/errno) dependencies.
- Redacted `Debug` implementations of secrets.

Closes Issue #3 