### PR TITLE
Update to use up-to-date `pairing` library.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,13 @@ categories = ["cryptography"]
 byteorder = "1.2.3"
 errno = "0.2.4"
 failure = "0.1"
+ff = "0.4.0"
 init_with = "1.1.0"
 lazy_static = "1.1.0"
 log = "0.4.1"
 memsec = "0.5.4"
-pairing = { version = "0.14.2", features = ["u128-support"] }
+# pairing = { version = "0.14.2", features = ["u128-support"] }
+pairing = { git = "https://github.com/zkcrypto/pairing", rev = "183a64b08e9dc7067f78624ec161371f1829623e" }
 rand = "0.4.2"
 rand_derive = "0.3.1"
 serde = "1.0.55"

--- a/src/into_fr.rs
+++ b/src/into_fr.rs
@@ -1,5 +1,5 @@
+use ff::{Field, PrimeField};
 use pairing::bls12_381::Fr;
-use pairing::{Field, PrimeField};
 
 /// A conversion into an element of the field `Fr`.
 pub trait IntoFr: Copy {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ extern crate byteorder;
 extern crate errno;
 #[macro_use]
 extern crate failure;
+extern crate ff;
 extern crate init_with;
 #[macro_use]
 extern crate lazy_static;
@@ -36,10 +37,11 @@ use std::ptr::{copy_nonoverlapping, write_volatile};
 
 use byteorder::{BigEndian, ByteOrder};
 use errno::errno;
+use ff::Field;
 use init_with::InitWith;
 use memsec::{memzero, mlock, munlock};
 use pairing::bls12_381::{Bls12, Fr, G1, G1Affine, G2, G2Affine};
-use pairing::{CurveAffine, CurveProjective, Engine, Field};
+use pairing::{CurveAffine, CurveProjective, Engine};
 use rand::{ChaChaRng, OsRng, Rand, Rng, SeedableRng};
 use tiny_keccak::sha3_256;
 

--- a/src/poly.rs
+++ b/src/poly.rs
@@ -23,9 +23,10 @@ use std::mem::{size_of, size_of_val};
 use std::{cmp, iter, ops};
 
 use errno::errno;
+use ff::Field;
 use memsec::{memzero, mlock, munlock};
 use pairing::bls12_381::{Fr, G1, G1Affine};
-use pairing::{CurveAffine, CurveProjective, Field};
+use pairing::{CurveAffine, CurveProjective};
 use rand::Rng;
 
 use super::{ContainsSecret, Error, IntoFr, Result, SHOULD_MLOCK_SECRETS};
@@ -927,8 +928,9 @@ mod tests {
 
     use super::{coeff_pos, BivarPoly, IntoFr, Poly};
 
+    use ff::Field;
     use pairing::bls12_381::{Fr, G1Affine};
-    use pairing::{CurveAffine, Field};
+    use pairing::CurveAffine;
     use rand;
 
     #[test]

--- a/src/serde_impl.rs
+++ b/src/serde_impl.rs
@@ -86,7 +86,7 @@ pub mod field_vec {
     use std::borrow::Borrow;
     use std::marker::PhantomData;
 
-    use pairing::{PrimeField, PrimeFieldRepr};
+    use ff::{PrimeField, PrimeFieldRepr};
     use serde::de::Error as DeserializeError;
     use serde::ser::Error as SerializeError;
     use serde::{Deserialize, Deserializer, Serialize, Serializer};


### PR DESCRIPTION
`u128-support` seems to have been removed, as the feature is in stable Rust and likely enabled in `ff` by default.

Most of the changes are name imports; the `ff` has been factored out. Once this is merged, https://github.com/poanetwork/hbbft/pull/211 will have to be merged as well.