### PR TITLE
Added 'try_' constructors to secret types.

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -19,8 +19,8 @@ mod poly_benches {
             "Polynomial multiplication",
             move |b, &&deg| {
                 let rand_factors = || {
-                    let lhs = Poly::random(deg, &mut rng).unwrap();
-                    let rhs = Poly::random(deg, &mut rng).unwrap();
+                    let lhs = Poly::random(deg, &mut rng);
+                    let rhs = Poly::random(deg, &mut rng);
                     (lhs, rhs)
                 };
                 b.iter_with_setup(rand_factors, |(lhs, rhs)| &lhs * &rhs)
@@ -36,7 +36,7 @@ mod poly_benches {
             "Polynomial interpolation",
             move |b, &&deg| {
                 let rand_samples = || (0..=deg).map(|i| (i, rng.gen::<Fr>())).collect::<Vec<_>>();
-                b.iter_with_setup(rand_samples, |samples| Poly::interpolate(samples).unwrap())
+                b.iter_with_setup(rand_samples, Poly::interpolate)
             },
             &[5, 10, 20, 40],
         );

--- a/examples/threshold_enc.rs
+++ b/examples/threshold_enc.rs
@@ -27,12 +27,12 @@ impl SecretSociety {
     // decrypt a message must exceed this `threshold`.
     fn new(n_actors: usize, threshold: usize) -> Self {
         let mut rng = rand::thread_rng();
-        let sk_set = SecretKeySet::random(threshold, &mut rng).unwrap();
+        let sk_set = SecretKeySet::random(threshold, &mut rng);
         let pk_set = sk_set.public_keys();
 
         let actors = (0..n_actors)
             .map(|id| {
-                let sk_share = sk_set.secret_key_share(id).unwrap();
+                let sk_share = sk_set.secret_key_share(id);
                 let pk_share = pk_set.public_key_share(id);
                 Actor::new(id, sk_share, pk_share)
             }).collect();

--- a/examples/threshold_sig.rs
+++ b/examples/threshold_sig.rs
@@ -45,12 +45,12 @@ impl ChatNetwork {
     // before it can be added to the `chat_log`.
     fn new(n_nodes: usize, threshold: usize) -> Self {
         let mut rng = rand::thread_rng();
-        let sk_set = SecretKeySet::random(threshold, &mut rng).unwrap();
+        let sk_set = SecretKeySet::random(threshold, &mut rng);
         let pk_set = sk_set.public_keys();
 
         let nodes = (0..n_nodes)
             .map(|id| {
-                let sk_share = sk_set.secret_key_share(id).unwrap();
+                let sk_share = sk_set.secret_key_share(id);
                 let pk_share = pk_set.public_key_share(id);
                 Node::new(id, sk_share, pk_share)
             }).collect();


### PR DESCRIPTION
- Added a set of "try_" prefixed constructors to secret types that can return an `Err` if memory locking fails. The non-"try_" prefixed constructors will panic in the event of a memory locking failure.
- Changed tests to use the non-"try_" prefixed constructors, because tests should be run with `MLOCK_SECRETS=false` and never fail for `mlock` related reasons.
- Improved the docstrings for secret-type constructors to differentiate those that panic from those that return an `Err`.

Closes issue #6