### PR TITLE
Typo fixes, added Code of Conduct file

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,73 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at andreas@poa.network. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,11 +9,11 @@ submitting code or comments.
 3. Write tests that cover your work.
 4. Run Rustfmt, Clippy, and all tests to ensure CI rules are satisfied.
    Correct versions and feature flags can be found in the
-   [`.travis.yml`](https://github.com/poanetwork/hbbft/blob/master/.travis.yml)
+   [`.travis.yml`](.travis.yml)
    file.
 5. Commit your changes (`git commit -am 'Add some feature'`).
 6. Push to your branch (`git push origin my-new-feature`).
-7. Create a new PR (Pull Request).
+7. Create a new Pull Request.
 
 ### General
 
@@ -34,11 +34,11 @@ submitting code or comments.
 
 ### Issues
 
-Creating and discussing [Issues](https://github.com/poanetwork/hbbft/issues)
+Creating and discussing [Issues](https://github.com/poanetwork/threshold_crypto/issues)
 provides significant value to the project. If you find a bug you can report it
 in an Issue.
 
-### Pull Requests
+### Pull Requests (PR)
 
 All pull requests should include:
 

--- a/examples/threshold_enc.rs
+++ b/examples/threshold_enc.rs
@@ -22,8 +22,8 @@ impl SecretSociety {
     //
     // # Arguments
     //
-    // `n_actors` - the number of operatives in the secret society.
-    // `threshold` - the number of operatives that must collaborate in in order to successfully
+    // `n_actors` - the number of actors (members) in the secret society.
+    // `threshold` - the number of actors that must collaborate to successfully
     // decrypt a message must exceed this `threshold`.
     fn new(n_actors: usize, threshold: usize) -> Self {
         let mut rng = rand::thread_rng();
@@ -101,7 +101,7 @@ impl DecryptionMeeting {
     fn accept_decryption_share(&mut self, actor: &mut Actor) {
         let ciphertext = actor.msg_inbox.take().unwrap();
 
-        // Check that the actor's ciphertext is the same that is being decrypted at the meeting.
+        // Check that the actor's ciphertext is the same ciphertext decrypted at the meeting.
         // The first actor to arrive at the decryption meeting sets the meeting's ciphertext.
         if let Some(ref meeting_ciphertext) = self.ciphertext {
             if ciphertext != *meeting_ciphertext {
@@ -132,7 +132,7 @@ fn main() {
     // Create a `SecretSociety` with 3 actors. Any message encrypted with the society's public-key
     // will require 2 or more actors working together to decrypt (i.e. the decryption threshold is
     // 1). Once the secret society has created its master keys, it "deals" a secret-key share and
-    // public-key share to each of its operatives. The secret society then publishes its public key
+    // public-key share to each of its actors. The secret society then publishes its public key
     // to a publicly accessible key-server.
     let mut society = SecretSociety::new(3, 1);
     let pk = society.publish_public_key();
@@ -143,8 +143,8 @@ fn main() {
     let clara = society.get_actor(2).id;
 
     // I, the society's benevolent hacker, want to send an important message to each of my
-    // comrades. I encrypt my message with the society's public-key, I then send the ciphertext to
-    // each of the society's operatives.
+    // comrades. I encrypt my message with the society's public-key. I then send the ciphertext to
+    // each of the society's actors.
     let msg = b"let's get pizza";
     let ciphertext = pk.encrypt(msg);
     send_msg(society.get_actor(alice), ciphertext.clone());


### PR DESCRIPTION
Minor grammar modifications to examples. I suggest changing 'operatives' to 'actors' for consistency in explanation, even though I like operatives better. 