### PR TITLE
Fix build failure if deadlinks is already installed.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
       - unzip
 before_install:
   - rustup component add --toolchain=${TRAVIS_RUST_VERSION} rustfmt-preview clippy-preview
-  - cargo install cargo-deadlinks
+  - cargo deadlinks --version || cargo install cargo-deadlinks
 env:
   global:
     - RUST_BACKTRACE=1


### PR DESCRIPTION
`cargo install` fails if it's already installed.