### PR TITLE
Add an API that allows specifying the RNG to be used for encryption.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,9 +101,17 @@ impl PublicKey {
         self.verify_g2(sig, hash_g2(msg))
     }
 
-    /// Encrypts the message.
+    /// Encrypts the message using the OS random number generator.
+    ///
+    /// Uses the `OsRng` by default. To pass in a custom random number generator, use
+    /// `encrypt_with_rng()`.
     pub fn encrypt<M: AsRef<[u8]>>(&self, msg: M) -> Ciphertext {
-        let r: Fr = OsRng::new().expect(ERR_OS_RNG).gen();
+        self.encrypt_with_rng(&mut OsRng::new().expect(ERR_OS_RNG), msg)
+    }
+
+    /// Encrypts the message.
+    pub fn encrypt_with_rng<R: Rng, M: AsRef<[u8]>>(&self, rng: &mut R, msg: M) -> Ciphertext {
+        let r: Fr = rng.gen();
         let u = G1Affine::one().mul(r);
         let v: Vec<u8> = {
             let g = self.0.into_affine().mul(r);


### PR DESCRIPTION
This is a small API extension that should be fully backwards compatible, but allows libraries to supply their own random number generator when calling `encrypt`.

This will soon be a required feature for `hbbft`, for this reason I would like to see this single change cherry picked for a `0.1.1` release.