### PR TITLE
Merge xor_vec and hash_bytes, validate polynomial degrees.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,8 @@ pub enum Error {
     NotEnoughShares,
     #[fail(display = "Signature shares contain a duplicated index")]
     DuplicateEntry,
+    #[fail(display = "The degree is too high for the coefficients to be indexed by usize.")]
+    DegreeTooHigh,
     #[fail(
         display = "Failed to `mlock` {} bytes starting at address: {}",
         n_bytes,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -864,6 +864,14 @@ mod tests {
     }
 
     #[test]
+    fn test_random_extreme_thresholds() {
+        let mut rng = rand::thread_rng();
+        let sks = SecretKeySet::random(0, &mut rng);
+        assert_eq!(0, sks.threshold());
+        assert!(SecretKeySet::try_random(usize::max_value(), &mut rng).is_err());
+    }
+
+    #[test]
     fn test_threshold_enc() {
         let mut rng = rand::thread_rng();
         let sk_set = SecretKeySet::random(3, &mut rng);


### PR DESCRIPTION
Fix a few issues pointed out in the code audit:
* `xor_vec` and `hash_bytes` are never used separately, and the API of `xor_vec` is a bit dangerous since it silently stops at the minimum of the two arguments' lengths.
* A polynomial has `degree + 1` coefficients, so creating one with degree `usize::max_value()` panics.
* `BivarPoly` and `BivarCommitment` have an invariant (`coeff.len() == coeff_pos(degree, degree) + 1`), which isn't verified on creation and deserialization.