### PR TITLE
Remove mlock.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,32 +51,20 @@ fn main() {
 Run tests using the following command:
 
 ```
-$ MLOCK_SECRETS=false cargo test
+$ cargo test
 ```
-
-The test suite runs quickly without setting the envvar `MLOCK_SECRETS=false`,
-but runs even faster when it is set. Setting this envvar also ensures that
-tests won't fail if we reach the testing system's locked memory limit (which
-we won't hit unless the system's locked memory limit is set unreasonably low,
-i.e. 1-2 pages or the equivalent, 4-8 kilobytes).
 
 ### Examples
 
 Run examples from the [`examples`](examples) directory using:
 
 ```
-$ MLOCK_SECRETS=false cargo run --example <example name>
+$ cargo run --example <example name>
 ```
 
 Also see the
 [distributed_key_generation](https://github.com/poanetwork/threshold_crypto/blob/d81953b55d181311c2a4eed2b6c34059fcf3fdae/src/poly.rs#L967)
 test.
-
-### Environment Variables
-
-[`MLOCK_SECRETS`](https://github.com/poanetwork/threshold_crypto/blob/master/src/lib.rs#L51): Sets whether or not the Unix syscall [`mlock`](http://man7.org/linux/man-pages/man2/mlock.2.html) or WinAPI function [`VirtualLock`](https://msdn.microsoft.com/en-us/library/windows/desktop/aa366895(v=vs.85).aspx) is called on portions of memory containing secret values. This option is enabled by default (`MLOCK_SECRETS=true`). Disabling memory locking (`MLOCK_SECRETS=false`) allows secret values to be copied to disk, where they will not be zeroed on drop and may persist indefinitely. **Disabling memory locking should only be done in development and testing.** 
-
-Disabling memory locking is useful because it removes the possibility of tests failing due to reaching the testing system's locked memory limit. For example, if your crate uses `threshold_crypto` and you write a test that maintains hundreds or thousands of secrets in memory simultaneously, you run the risk of reaching your system's allowed number of locked pages, which will cause this library to fail.
 
 ## Application Details
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,5 @@
 //! Crypto errors.
 
-use errno::Errno;
-
 /// A crypto error.
 #[derive(Clone, Eq, PartialEq, Debug, Fail)]
 pub enum Error {
@@ -11,32 +9,6 @@ pub enum Error {
     DuplicateEntry,
     #[fail(display = "The degree is too high for the coefficients to be indexed by usize.")]
     DegreeTooHigh,
-    #[fail(
-        display = "Failed to `mlock` {} bytes starting at address: {}",
-        n_bytes,
-        addr
-    )]
-    MlockFailed {
-        // The errno set by the failed `mlock` syscall.
-        errno: Errno,
-        // The address for the first byte in the range of memory that was attempted to be locked.
-        addr: String,
-        // The number of bytes that were attempted to be locked.
-        n_bytes: usize,
-    },
-    #[fail(
-        display = "Failed to `munlock` {} bytes starting at address: {}",
-        n_bytes,
-        addr
-    )]
-    MunlockFailed {
-        // The errno set by the failed `munlock` syscall.
-        errno: Errno,
-        // The address for the first byte in the range of memory that was attempted to be unlocked.
-        addr: String,
-        // The number of bytes that were attempted to be unlocked.
-        n_bytes: usize,
-    },
 }
 
 unsafe impl Send for Error {}

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -7,8 +7,6 @@ use std::ops::{Deref, DerefMut};
 use memsec::memzero;
 use Fr;
 
-use error::Result;
-
 lazy_static! {
     /// The size in bytes of a single field element.
     pub(crate) static ref FR_SIZE: usize = size_of::<Fr>();
@@ -89,10 +87,6 @@ where
     T: DerefMut,
 {
     pub(crate) fn new(x: T) -> Self {
-        Safe::try_new(x).unwrap_or_else(|e| panic!("Failed to create `Safe`: {}", e))
-    }
-
-    pub(crate) fn try_new(x: T) -> Result<Self> {
-        Ok(Safe(x))
+        Safe(x)
     }
 }

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -1,32 +1,15 @@
-//! Utilities for working with secret values. This module includes functionality for locking (and
-//! unlocking) memory into RAM and overwriting memory with zeros.
+//! Utilities for working with secret values. This module includes functionality for overwriting
+//! memory with zeros.
 
-use std::env;
 use std::mem::{size_of, size_of_val};
 use std::ops::{Deref, DerefMut};
 
-use errno::errno;
-use memsec::{memzero, mlock, munlock};
+use memsec::memzero;
 use Fr;
 
-use error::{Error, Result};
+use error::Result;
 
 lazy_static! {
-    /// Sets whether or not `mlock`ing is enabled. Memory locking is enabled by default; it can be
-    /// disabled by setting the environment variable `MLOCK_SECRETS=false`. This is useful when you
-    /// are running on a system where you do not have the ability to increase the systems locked
-    /// memory limit (which can be found using the Unix command: `ulimit -l`). For example, we
-    /// disable `mlock`ing of secrets when testing crates that depend on `threshold_crypto` when
-    /// running in Travis CI because Travis has a locked memory limit of 64kb, which we may exceed
-    /// while running `cargo test`. Disabling `mlock`ing for secret values allows secret keys to
-    /// be swapped/core-dumped to disk, resulting in unmanaged copies of secrets to hang around in
-    /// memory; this is significantly less secure than enabling memory locking (the default). Only
-    /// set `MLOCK_SECRETS=false` in development/testing.
-    pub(crate) static ref SHOULD_MLOCK_SECRETS: bool = match env::var("MLOCK_SECRETS") {
-        Ok(s) => s.parse().unwrap_or(true),
-        _ => true,
-    };
-
     /// The size in bytes of a single field element.
     pub(crate) static ref FR_SIZE: usize = size_of::<Fr>();
 }
@@ -46,73 +29,6 @@ pub(crate) trait ContainsSecret {
     /// Returns the range of memory marked as secret.
     fn secret_memory(&self) -> MemRange;
 
-    /// Locks a region of memory marked as secret into RAM.
-    ///
-    /// The region of memory marked as secret will not be copied to disk, for example, during a
-    /// swap-to-disk or core dump. This method should be called upon instantiation of every type
-    /// that implements `ContainsSecret`.
-    ///
-    /// Operating systems set a limit on the ammount of memory that a process may lock into RAM.
-    /// Due to this limitation, this method returns a `Result` in the event that memory locking
-    /// fails.
-    ///
-    /// # Errors
-    ///
-    /// An `Error::MlockFailed` is returned if we reach the system's locked memory limit or if  we
-    /// attempt to lock an invalid region of memory.
-    fn mlock_secret(&self) -> Result<()> {
-        if !*SHOULD_MLOCK_SECRETS {
-            return Ok(());
-        }
-        let MemRange { ptr, n_bytes } = self.secret_memory();
-        if n_bytes == 0 {
-            return Ok(());
-        }
-        let mlock_succeeded = unsafe { mlock(ptr, n_bytes) };
-        if mlock_succeeded {
-            Ok(())
-        } else {
-            let e = Error::MlockFailed {
-                errno: errno(),
-                addr: format!("{:?}", ptr),
-                n_bytes,
-            };
-            Err(e)
-        }
-    }
-
-    /// Unlocks the memory lock for a region of memory marked as secret. If the secret region of
-    /// memory had not previosly been locked via the `.mlock_secret()` method, then this method
-    /// does nothing.
-    ///
-    /// Once this method has been called, the secret region of memory will no longer be protected
-    /// from being copied to disk. This method should be called upon destruction of every type that
-    /// implements `ContainsSecret`.
-    ///
-    /// # Errors
-    ///
-    /// An `Error::MlockFailed` is returned if we attempt to lock an invalid region memory.
-    fn munlock_secret(&self) -> Result<()> {
-        if !*SHOULD_MLOCK_SECRETS {
-            return Ok(());
-        }
-        let MemRange { ptr, n_bytes } = self.secret_memory();
-        if n_bytes == 0 {
-            return Ok(());
-        }
-        let munlock_succeeded = unsafe { munlock(ptr, n_bytes) };
-        if munlock_succeeded {
-            Ok(())
-        } else {
-            let e = Error::MunlockFailed {
-                errno: errno(),
-                addr: format!("{:?}", ptr),
-                n_bytes,
-            };
-            Err(e)
-        }
-    }
-
     /// Overwrites the secret region of memory with zeros.
     ///
     /// This method should be called upon destruction of every type that implements `ContainsSecret`.
@@ -122,7 +38,7 @@ pub(crate) trait ContainsSecret {
     }
 }
 
-/// A wrapper around temporary values to ensuer that they are locked into RAM and cleared on drop.
+/// A wrapper around temporary values to ensuer that they are cleared on drop.
 ///
 /// `Safe<T>` is meant to be used a wrapper around `T`, where `T` is  either an `&mut U` or
 /// `Box<U>`.
@@ -154,9 +70,6 @@ where
 {
     fn drop(&mut self) {
         self.zero_secret();
-        if let Err(e) = self.munlock_secret() {
-            panic!("Failed to drop `Safe`: {}", e);
-        }
     }
 }
 
@@ -180,8 +93,6 @@ where
     }
 
     pub(crate) fn try_new(x: T) -> Result<Self> {
-        let safe = Safe(x);
-        safe.mlock_secret()?;
-        Ok(safe)
+        Ok(Safe(x))
     }
 }


### PR DESCRIPTION
It currently causes too many problems to be practical. We will re-enable it once we have a dedicated allocator for locked memory.

This also removes the `try_` methods for now, because errors are only returned if m[un]locking fails.