### PR TITLE
Added a bit iterator for signatures

### DIFF
--- a/src/bit_iterator.rs
+++ b/src/bit_iterator.rs
@@ -1,0 +1,32 @@
+#[derive(Debug, Clone)]
+/// An iterator of bits in finite sequential data.
+pub struct BitIterator<E> {
+    /// Data for iterating over.
+    t: E,
+    /// The number of remaining bits until the end.
+    n: usize,
+}
+
+impl<E: AsRef<[u8]>> BitIterator<E> {
+    /// Creates a new iterator for the given data and sets the number of remaining bits.
+    pub fn new(t: E) -> Self {
+        let n = t.as_ref().len() * 8;
+        BitIterator { t, n }
+    }
+}
+
+// FIXME: tests!
+impl<E: AsRef<[u8]>> Iterator for BitIterator<E> {
+    type Item = bool;
+
+    fn next(&mut self) -> Option<bool> {
+        if self.n == 0 {
+            None
+        } else {
+            self.n -= 1;
+            let part = self.n / 8;
+            let bit = self.n - (8 * part);
+            Some(self.t.as_ref()[part] & (1 << bit) > 0)
+        }
+    }
+}

--- a/src/bit_iterator.rs
+++ b/src/bit_iterator.rs
@@ -15,18 +15,44 @@ impl<E: AsRef<[u8]>> BitIterator<E> {
     }
 }
 
-// FIXME: tests!
 impl<E: AsRef<[u8]>> Iterator for BitIterator<E> {
     type Item = bool;
 
+    /// Iterates data bits starting with the least significant bit.
     fn next(&mut self) -> Option<bool> {
         if self.n == 0 {
             None
         } else {
             self.n -= 1;
-            let part = self.n / 8;
-            let bit = self.n - (8 * part);
-            Some(self.t.as_ref()[part] & (1 << bit) > 0)
+            let byte = self.n / 8;
+            let bit = 7 - (self.n - (8 * byte));
+            Some(self.t.as_ref()[byte] & (1 << bit) > 0)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BitIterator;
+    use rand::{self, Rng};
+
+    #[test]
+    fn test_bit_iterator() {
+        const LEN: usize = 20;
+        let mut rng = rand::thread_rng();
+        let u: Vec<u8> = (0..LEN).map(|_| rng.gen()).collect();
+        let mut bits = BitIterator::new(u.clone());
+        let mut v = Vec::new();
+        for _byte in 0..LEN {
+            let mut o: u8 = 0;
+            for bit in 0..8 {
+                if let Some(b) = bits.next() {
+                    o |= (b as u8) << bit;
+                }
+            }
+            v.push(o);
+        }
+        v.reverse();
+        assert_eq!(u, v);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ mod mock;
 #[cfg(feature = "use-insecure-test-only-mock-crypto")]
 pub use mock::{
     Mersenne8 as Fr, Mocktography as PEngine, Ms8Affine as G1Affine, Ms8Affine as G2Affine,
-    Ms8Projective as G1, Ms8Projective as G2,
+    Ms8Compressed as G2Compressed, Ms8Projective as G1, Ms8Projective as G2,
 };
 
 /// The number of words (`u32`) in a ChaCha RNG seed.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -850,4 +850,34 @@ mod tests {
         let deser_sig = bincode::deserialize(&ser_sig).expect("deserialize signature");
         assert_eq!(sig, deser_sig);
     }
+
+    /// Tests of random bit distribution within signatures using `BitIterator`.
+    #[test]
+    fn test_signature_bit_iterator() {
+        let sk: SecretKey = random();
+        let msg0 = b"Tenant signature: ______";
+        let sig0 = sk.sign(msg0);
+        let bits0 = sig0.bit_iter();
+        let msg1 = b"Landlord signature: ______";
+        let sig1 = sk.sign(msg1);
+        let bits1 = sig1.bit_iter();
+        let msg2 = b"Agent signature: ______";
+        let sig2 = sk.sign(msg2);
+        let bits2 = sig2.bit_iter();
+        let mut count: usize = 0;
+        let mut count_any = 0;
+        let mut count_all = 0;
+        for (b0, (b1, b2)) in bits0.zip(bits1.zip(bits2)) {
+            count += 1;
+            if b0 || b1 || b2 {
+                count_any += 1;
+            }
+            if b0 && b1 && b2 {
+                count_all += 1;
+            }
+        }
+        assert!(count > 0);
+        assert!(count_any >= count / 3);
+        assert!(count_all < count / 3);
+    }
 }

--- a/src/mock/mod.rs
+++ b/src/mock/mod.rs
@@ -29,6 +29,9 @@ pub struct Mocktography;
 #[derive(Copy, Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Ms8Affine(Mersenne8);
 
+/// Alias for the compressed representation.
+pub type Ms8Compressed = Ms8Affine;
+
 /// Projective type for `Mersenne8`.
 #[derive(Copy, Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Ms8Projective(Mersenne8);
@@ -200,6 +203,10 @@ impl CurveAffine for Ms8Affine {
 
     fn into_projective(&self) -> Self::Projective {
         Ms8Projective(self.0)
+    }
+
+    fn into_compressed(&self) -> Self::Compressed {
+        *self
     }
 }
 


### PR DESCRIPTION
This was supposed to be a pair PR with the matching `hbbft` [branch](https://github.com/poanetwork/hbbft/tree/vk-random-value) to add a `random_value` [optimization](https://github.com/poanetwork/hbbft/issues/183#issuecomment-423962634) in Binary Agreement. However it can have other uses, e.g., emulating random coin flips given a signature.