### PR TITLE
Don’t allow calling `reveal` in release builds

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -487,6 +487,7 @@ impl SecretKey {
     /// Generates a non-redacted debug string. This method differs from
     /// the `Debug` implementation in that it *does* leak the secret prime
     /// field element.
+    #[cfg(debug_assertions)]
     pub fn reveal(&self) -> String {
         let uncomp = self.public_key().0.into_affine().into_uncompressed();
         let bytes = uncomp.as_ref();
@@ -580,6 +581,7 @@ impl SecretKeyShare {
     /// Generates a non-redacted debug string. This method differs from
     /// the `Debug` implementation in that it *does* leak the secret prime
     /// field element.
+    #[cfg(debug_assertions)]
     pub fn reveal(&self) -> String {
         let uncomp = self.0.public_key().0.into_affine().into_uncompressed();
         let bytes = uncomp.as_ref();

--- a/src/poly.rs
+++ b/src/poly.rs
@@ -699,6 +699,7 @@ impl Poly {
     /// Generates a non-redacted debug string. This method differs from
     /// the `Debug` implementation in that it *does* leak the secret prime
     /// field elements.
+    #[cfg(debug_assertions)]
     pub fn reveal(&self) -> String {
         format!("Poly {{ coeff: {:?} }}", self.coeff)
     }
@@ -982,6 +983,7 @@ impl BivarPoly {
     /// Generates a non-redacted debug string. This method differs from the
     /// `Debug` implementation in that it *does* leak the the struct's
     /// internal state.
+    #[cfg(debug_assertions)]
     pub fn reveal(&self) -> String {
         format!(
             "BivarPoly {{ degree: {}, coeff: {:?} }}",


### PR DESCRIPTION
Some structs have a `reveal` method, which deliberately leaks secret
information for debug builds.  There is no legitimate reason to use
them for anything other than debugging, and no uses at all in any of the
other codebases I am working on.

To ensure that no new uses of this method are added, make this method
only available when debug assertions are turned on.  This ensures that
any attempts to uses this method will break release builds, and thus be
quickly discovered.