### PR TITLE
Implement serde for secret keys

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,6 +254,11 @@ impl SignatureShare {
 /// A secret key; wraps a single prime field element. The field element is
 /// heap allocated to avoid any stack copying that result when passing
 /// `SecretKey`s between stack frames.
+///
+/// # Serde integration
+/// `SecretKey` implements `Deserialize` but not `Serialize` to avoid accidental
+/// serialization in insecure contexts. To enable both use the `::serde_impl::SerdeSecret`
+/// wrapper which implements both `Deserialize` and `Serialize`.
 #[derive(PartialEq, Eq)]
 pub struct SecretKey(Box<Fr>);
 
@@ -364,6 +369,11 @@ impl SecretKey {
 }
 
 /// A secret key share.
+///
+/// # Serde integration
+/// `SecretKeyShare` implements `Deserialize` but not `Serialize` to avoid accidental
+/// serialization in insecure contexts. To enable both use the `::serde_impl::SerdeSecret`
+/// wrapper which implements both `Deserialize` and `Serialize`.
 #[derive(Clone, PartialEq, Eq, Default)]
 pub struct SecretKeyShare(SecretKey);
 

--- a/src/serde_impl.rs
+++ b/src/serde_impl.rs
@@ -3,6 +3,7 @@
 pub use self::field_vec::FieldWrap;
 
 use std::borrow::Cow;
+use std::ops::Deref;
 
 use crate::G1;
 use serde::de::Error as DeserializeError;
@@ -10,8 +11,62 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_derive::{Deserialize, Serialize};
 
 use crate::poly::{coeff_pos, BivarCommitment};
+use crate::serde_impl::serialize_secret_internal::SerializeSecret;
 
 const ERR_DEG: &str = "commitment degree does not match coefficients";
+
+pub(crate) mod serialize_secret_internal {
+    use serde::Serializer;
+
+    /// To avoid deriving [`Serialize`] automatically for structs containing secret keys this trait
+    /// should be implemented instead. It only enables explicit serialization through
+    /// [`::serde_impls::SerdeSecret`].
+    pub trait SerializeSecret {
+        fn serialize_secret<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error>;
+    }
+}
+
+/// `SerdeSecret` is a wrapper struct for serializing and deserializing secret keys. Due to security
+/// concerns serialize shouldn't be implemented for secret keys to avoid accidental leakage.
+///
+/// Whenever this struct is used the integrity of security boundaries should be checked carefully.
+pub struct SerdeSecret<T>(T);
+
+impl<T> Deref for SerdeSecret<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.inner()
+    }
+}
+
+impl<T> SerdeSecret<T> {
+    /// Returns the actual secret from the wrapper
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+
+    /// Returns a reference to the actual secret contained in the wrapper
+    pub fn inner(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<'de, T: Deserialize<'de>> Deserialize<'de> for SerdeSecret<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where
+        D: Deserializer<'de>
+    {
+        Ok(SerdeSecret(Deserialize::deserialize(deserializer)?))
+    }
+}
+
+impl<'de, T: SerializeSecret> Serialize for SerdeSecret<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where
+        S: Serializer
+    {
+        self.0.serialize_secret(serializer)
+    }
+}
 
 /// A type with the same content as `BivarCommitment`, but that has not been validated yet.
 #[derive(Serialize, Deserialize)]


### PR DESCRIPTION
Fixes #73 . This implements a wrapper struct for secret keys `SerdeSecret` that enables these to be serialized and deserialized. I only intend to implement this for the non-mocked crypto because I didn't find a good generic interface to ser/de the underlying `Fr` struct, so I'm currently just taking the `pub [u64, 4]` out of the `FrRepr`.

- [x] impl for `SecretKey`
- [x] impl for `SecretKeyShare`
- [ ] think about how to erase all stack copies of key material