### PR TITLE
Using the serde derive feature instead of the crate serde_derive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-    - 1.31.0
+    - 1.33.0
 cache:
   cargo: true
   timeout: 1200

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,17 +27,15 @@ lazy_static = "1.1.0"
 log = "0.4.6"
 memsec = "0.5.4"
 pairing = { version = "0.14.2", features = ["u128-support"] }
-rand = "0.6.4"
+rand = "0.6.5"
 rand04_compat = "0.1.1"
 rand_chacha = "0.1.1"
-serde = "1.0.84"
-serde_derive = "1.0.84"
+serde = { version = "1.0.89", features = ["derive"] }
 tiny-keccak = "1.4.2"
 
 [dev-dependencies]
 bincode = "1.0.1"
 criterion = "0.2.7"
-serde_derive = "1.0.84"
 rand_xorshift = "0.1.1"
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "threshold_crypto"
 # REMINDER: Update version in `README.md` when incrementing:
-version = "0.3.0"
+version = "0.3.1"
 authors = [
     "Vladimir Komendantskiy <komendantsky@gmail.com>",
     "Andreas Fackler <AndreasFackler@gmx.de>",

--- a/examples/basic_pkc.rs
+++ b/examples/basic_pkc.rs
@@ -1,5 +1,5 @@
 use bincode::{deserialize, serialize};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use threshold_crypto::{PublicKey, SecretKey, Signature};
 
 #[derive(Deserialize, Serialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ use rand::distributions::{Distribution, Standard};
 use rand::{rngs::OsRng, Rng, SeedableRng};
 use rand04_compat::RngExt;
 use rand_chacha::ChaChaRng;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use tiny_keccak::sha3_256;
 
 use crate::cmp_pairing::cmp_projective;

--- a/src/poly.rs
+++ b/src/poly.rs
@@ -26,7 +26,7 @@ use std::{cmp, iter, ops};
 use pairing::{CurveAffine, CurveProjective, Field};
 use rand::Rng;
 use rand04_compat::RngExt;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use crate::cmp_pairing::cmp_projective;
 use crate::error::{Error, Result};

--- a/src/serde_impl.rs
+++ b/src/serde_impl.rs
@@ -8,7 +8,6 @@ use std::ops::Deref;
 use crate::G1;
 use serde::de::Error as DeserializeError;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use serde_derive::{Deserialize, Serialize};
 
 use crate::poly::{coeff_pos, BivarCommitment};
 use crate::serde_impl::serialize_secret_internal::SerializeSecret;
@@ -322,7 +321,7 @@ mod tests {
     use bincode;
     use rand;
     use rand04_compat::RngExt;
-    use serde_derive::{Deserialize, Serialize};
+    use serde::{Deserialize, Serialize};
 
     use crate::poly::BivarPoly;
     use crate::{Fr, G1};


### PR DESCRIPTION
The upgrade to the latest `serde` and using the `derive` feature reportedly fixed the issue in #78 although I wasn't able to reproduce it.