### PR TITLE
Make `reveal` print the secret key, not the public one.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -402,8 +402,7 @@ impl SecretKey {
     /// the `Debug` implementation in that it *does* leak the secret prime
     /// field element.
     pub fn reveal(&self) -> String {
-        let uncomp = self.public_key().0.into_affine().into_uncompressed();
-        format!("SecretKey({:0.10})", HexFmt(uncomp))
+        format!("SecretKey({:?})", self.0)
     }
 }
 
@@ -474,8 +473,7 @@ impl SecretKeyShare {
     /// the `Debug` implementation in that it *does* leak the secret prime
     /// field element.
     pub fn reveal(&self) -> String {
-        let uncomp = self.0.public_key().0.into_affine().into_uncompressed();
-        format!("SecretKeyShare({:0.10})", HexFmt(uncomp))
+        format!("SecretKeyShare({:?})", (self.0).0)
     }
 }
 


### PR DESCRIPTION
That's what the method documentation says. It explicitly warns that it
reveals the secret key, unlike the `Debug` implementation.

An example output from the tests:
```rust
SecretKey(Fr(FrRepr([17796403590321401452, 5186408160561640781, 5316101836953068894, 4215027201736618979])))
```