### PR TITLE
Make SecretKeySet cloneable. Rust 1.42.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.39.0
+  - 1.42.0
 cache:
   cargo: true
   timeout: 1200

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -635,6 +635,7 @@ impl PublicKeySet {
 }
 
 /// A secret key and an associated set of secret key shares.
+#[derive(Clone, PartialEq, Eq)]
 pub struct SecretKeySet {
     /// The coefficients of a polynomial whose value at `0` is the "master key", and value at
     /// `i + 1` is key share number `i`.


### PR DESCRIPTION
Closes #97