### PR TITLE
Add reveal to commitment and bivarcommitment

### DIFF
--- a/src/poly.rs
+++ b/src/poly.rs
@@ -513,6 +513,11 @@ impl Commitment {
         let len = self.coeff.len() - zeros;
         self.coeff.truncate(len)
     }
+
+    /// Generates a non-redacted debug string
+    pub fn reveal(&self) -> String {
+        format!("Commitment {{ coeff: {:?} }}", self.coeff)
+    }
 }
 
 /// A symmetric bivariate polynomial in the prime field.
@@ -728,6 +733,16 @@ impl BivarCommitment {
     /// Returns the `0`-th to `degree`-th power of `x`.
     fn powers<T: IntoFr>(&self, x: T) -> Vec<Fr> {
         powers(x, self.degree)
+    }
+
+    /// Generates a non-redacted debug string. This method differs from the
+    /// `Debug` implementation in that it *does* leak the the struct's
+    /// internal state.
+    pub fn reveal(&self) -> String {
+        format!(
+            "BivarCommitment {{ degree: {}, coeff: {:?} }}",
+            self.degree, self.coeff
+        )
     }
 }
 


### PR DESCRIPTION
These `reveal` functions are not necessary but I find them slightly helpful to debug, I figured if the polynomial and bivariate polynomial have it, I'll add it to the other structs for completeness sake. Leaving it to the maintainers if you want to land this.