### PR TITLE
Release Version 0.4.1 (#114) without failure crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "threshold_crypto"
 # REMINDER: Update version in `README.md` when incrementing:
-version = "0.4.0"
+version = "0.4.1"
 authors = [
     "Vladimir Komendantskiy <komendantsky@gmail.com>",
     "Andreas Fackler <AndreasFackler@gmx.de>",

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ An [official security audit](https://github.com/poanetwork/wiki/wiki/Threshold-C
 
 ```toml
 [dependencies]
-threshold_crypto = { version = "0.4", git = "https://github.com/poanetwork/threshold_crypto" }
+threshold_crypto = { version = "0.4.1", git = "https://github.com/poanetwork/threshold_crypto" }
 ```
 
 `main.rs`:
@@ -103,7 +103,7 @@ by third-parties as representing the consensus of the network.
 ### Documentation
 
 * [crate documentation](https://docs.rs/threshold_crypto/)
-* [crates.io package](https://crates.io/crates/threshold_crypto) 
+* [crates.io package](https://crates.io/crates/threshold_crypto)
 
 ## Performance
 


### PR DESCRIPTION
Release Version 0.4.1 without the deprecated failure crate. 